### PR TITLE
Increase bundle version

### DIFF
--- a/MachOView-master/Info.plist
+++ b/MachOView-master/Info.plist
@@ -5,7 +5,7 @@
 	<key>CFBuildDate</key>
 	<string>Wed Aug 28 11:35:20 CST 2019</string>
 	<key>CFBuildNumber</key>
-	<string>271</string>
+	<string>10271</string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>English</string>
 	<key>CFBundleDocumentTypes</key>
@@ -44,7 +44,7 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>271</string>
+	<string>10271</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.developer-tools</string>
 	<key>LSMinimumSystemVersion</key>


### PR DESCRIPTION
The original MachOView (v2.4) by psaghelyi on SourceForge has the bundle ID `9201`, and that leads to problems that automated app updaters won't recognize e.g. your v2.6.1 as an update. So I increased the bundle ID from `271` to `10271`, keeping the original numbering scheme (271), but adding 10,000 to put it safely ahead of the original v2.4.